### PR TITLE
update instructions for 2.43.1 preupgrade

### DIFF
--- a/upgrade/v2.43.1.md
+++ b/upgrade/v2.43.1.md
@@ -52,10 +52,8 @@ Update your app.toml config in `~/.carbon/config/app.toml`, under `gRPC Configur
     Restart **BOTH** your oracle service and validator node if they are running.
 </details>
 
-<br>
-
 <h2>
-**:exclamation: If you run your oracle service and validator node on **DIFFERENT** machines, follow these instructions instead :exclamation:**
+:exclamation: If you run your oracle service and validator node on **DIFFERENT** machines, follow these instructions instead :exclamation:
 </h2>
 
 <details>

--- a/upgrade/v2.43.1.md
+++ b/upgrade/v2.43.1.md
@@ -1,29 +1,103 @@
 # MainNet v2.43.0 -> v2.43.1 Pre-Upgrade Instructions
 
-The following instruction will allow patch your node from v2.43.0 to v2.43.1.
+The following patch is necessary if you are running our oracle service.
 
-1. Run the following commands to generate ssl configurations, that will be used to authenticate GRPC server.
+**:exclamation: If you run your oracle service and validator node on the **SAME** machine, follow these instructions :exclamation:**
 
-    **:exclamation: If you run your oracle service and validator node on separate machines, update the following `VALIDATOR_NODE_IP_ADDRESS` and `ORACLE_SERVICE_NODE_IP_ADDRESS` fields with the private IP address of each machine.:exclamation:**
-
+<details>
+<summary> Instructions </summary>
+<h3>
+1. Run the following commands on your **VALIDATOR NODE** to generate ssl configurations, that will be used to authenticate GRPC server.
+</h3>
+<br>
     ```bash
-    VALIDATOR_NODE_IP_ADDRESS="127.0.0.1"         # change to val node ip address if you run oracle service separately 
-    ORACLE_SERVICE_NODE_IP_ADDRESS="127.0.0.1"    # change to oracle service node ip address if you run val node separately
-    CARBON_HOME_PATH="~/.carbon"                  # change to your own directory path where the .carbon directory is found
+    VALIDATOR_NODE_IP_ADDRESS="127.0.0.1"         
+    ORACLE_SERVICE_NODE_IP_ADDRESS="127.0.0.1"    
+    CARBON_HOME_PATH="~/.carbon"         # change to your own directory path where the .carbon directory is found
     URL=https://raw.githubusercontent.com/yan-soon/carbon-bootstrap/master/scripts/cert.sh
     bash <(wget -O - $URL) $VALIDATOR_NODE_IP_ADDRESS $ORACLE_SERVICE_NODE_IP_ADDRESS $CARBON_HOME_PATH
     ```
+<br>
+**:memo: If you wish to disable the gRPC authentication, follow these instructions. :memo:**
+<br>
 
-
-**:exclamation: If you wish to disable the gRPC authentication, follow the next few steps. :exclamation:**
-
+<h4>
 Update your app.toml config in `~/.carbon/config/app.toml`, under `gRPC Configuration`.
+</h4>
     
-    Set the following field `disable-oracle-grpc-auth` to `true`:
+    Set the following field `enable-oracle-grpc-auth` to `false`:
 
     ```
-    # DisableOracleGrpcAuth defines if the gRPC server for oracle votes communication should be ssl authenticated.
-    disable-oracle-grpc-auth = true
+    # EnableOracleGrpcAuth defines if the gRPC server for oracle votes communication should be ssl authenticated.
+    enable-oracle-grpc-auth = false
     ```
 
-    Restart both your oracle service and validator node if they are running.
+    Restart **BOTH** your oracle service and validator node if they are running.
+</details>
+
+<br>
+
+**:exclamation: If you run your oracle service and validator node on **DIFFERENT** machines, follow these instructions instead :exclamation:**
+
+<details>
+<summary> Instructions </summary>
+<br>
+<h3> 1. Run the following commands on your **VALIDATOR NODE** to generate ssl configurations, that will be used to authenticate GRPC server.
+</h3>
+
+<br>
+
+**:exclamation: Update the following fields, `VALIDATOR_NODE_IP_ADDRESS` and `ORACLE_SERVICE_NODE_IP_ADDRESS` with the private IP address of each machine. :exclamation:**
+
+<br>
+
+```bash
+VALIDATOR_NODE_IP_ADDRESS=""         # change to val node ip address if you run oracle service separately 
+ORACLE_SERVICE_NODE_IP_ADDRESS=""    # change to oracle service node ip address if you run val node separately
+CARBON_HOME_PATH="~/.carbon"         # change to your own directory path where the .carbon directory is found
+URL=https://raw.githubusercontent.com/yan-soon/carbon-bootstrap/master/scripts/cert.sh
+bash <(wget -O - $URL) $VALIDATOR_NODE_IP_ADDRESS $ORACLE_SERVICE_NODE_IP_ADDRESS $CARBON_HOME_PATH
+```
+
+<br>
+<h3>2. Transfer the ssl certificates to your oracle node. </h3>
+<br>
+
+**:exclamation: Update the following fields, `VALIDATOR_NODE_IP_ADDRESS` and `HOST_NAME` with the private IP address and the Host Name of your validator node. :exclamation:**
+<br>
+
+**:memo: Update the file paths accordingly if your id_rsa key, and carbon home directory are stored differently. (If ssh entry to your nodes do not require verification, you can remove the -i option, can omit `-i ~/.ssh/id_rsa `) :memo:**
+
+```bash
+scp -r -i ~/.ssh/id_rsa  HOST_NAME@VALIDATOR_NODE_IP_ADDRESS:~/.carbon/config/cert ~/.carbon/config/cert 
+```
+
+<h3>
+3. Starting up your oracle service
+</h3>
+
+When running your oracle service, you now have to supply an additional flag for the new grpc url:
+
+**:exclamation: Update the following fields, `VALIDATOR_NODE_IP_ADDRESS` with the private IP address of your validator node. :exclamation:**
+<br>
+
+```
+carbond oracle --grpc-url VALIDATOR_NODE_IP_ADDRESS:9090 --oracle-grpc-url VALIDATOR_NODE_IP_ADDRESS:9093
+```
+
+<br>
+**:memo: If you wish to disable the gRPC authentication, follow these instructions. :memo:**
+<br><br>
+
+Update your app.toml config in `~/.carbon/config/app.toml`, under `gRPC Configuration`, on **BOTH VALIDATOR NODE AND ORACLE SERVICE NODE**
+    
+    Set the following field `enable-oracle-grpc-auth` to `false`:
+
+    ```
+    # EnableOracleGrpcAuth defines if the gRPC server for oracle votes communication should be ssl authenticated.
+    enable-oracle-grpc-auth = false
+    ```
+
+    Restart **BOTH** your oracle service and validator node if they are running.
+
+</details>

--- a/upgrade/v2.43.1.md
+++ b/upgrade/v2.43.1.md
@@ -2,7 +2,24 @@
 
 The following patch is necessary if you are running our oracle service.
 
-**:exclamation: If you run your oracle service and validator node on the **SAME** machine, follow these instructions :exclamation:**
+<h2>
+Check if you are running your oracle service on a separate machine
+</h2>
+
+Run the following command inside your **VALIDATOR NODE**:
+<br><br>
+    ```
+    cat /etc/systemd/system/carbond.service | grep Wants=carbond@oracle.service
+    ```
+
+If you get the following response: `Wants=carbond@oracle.service` -> you are running your oracle service and validator on the **SAME** machine.
+
+If you get no response -> you are running your oracle service and validator on **DIFFERENT** machines.
+<br><br>
+
+<h2>
+:exclamation:If you run your oracle service and validator node on the **SAME** machine, follow these instructions :exclamation:
+</h2>
 
 <details>
 <summary> Instructions </summary>
@@ -18,7 +35,7 @@ The following patch is necessary if you are running our oracle service.
     bash <(wget -O - $URL) $VALIDATOR_NODE_IP_ADDRESS $ORACLE_SERVICE_NODE_IP_ADDRESS $CARBON_HOME_PATH
     ```
 <br>
-**:memo: If you wish to disable the gRPC authentication, follow these instructions. :memo:**
+:bulb: If you wish to disable the gRPC authentication, follow these instructions. :bulb:**
 <br>
 
 <h4>
@@ -37,7 +54,9 @@ Update your app.toml config in `~/.carbon/config/app.toml`, under `gRPC Configur
 
 <br>
 
+<h2>
 **:exclamation: If you run your oracle service and validator node on **DIFFERENT** machines, follow these instructions instead :exclamation:**
+</h2>
 
 <details>
 <summary> Instructions </summary>
@@ -66,7 +85,7 @@ bash <(wget -O - $URL) $VALIDATOR_NODE_IP_ADDRESS $ORACLE_SERVICE_NODE_IP_ADDRES
 **:exclamation: Update the following fields, `VALIDATOR_NODE_IP_ADDRESS` and `HOST_NAME` with the private IP address and the Host Name of your validator node. :exclamation:**
 <br>
 
-**:memo: Update the file paths accordingly if your id_rsa key, and carbon home directory are stored differently. (If ssh entry to your nodes do not require verification, you can remove the -i option, can omit `-i ~/.ssh/id_rsa `) :memo:**
+**:bulb: Update the file paths accordingly if your id_rsa key, and carbon home directory are stored differently. (If ssh entry to your nodes do not require verification, you can remove the -i option, can omit `-i ~/.ssh/id_rsa `) :bulb:**
 
 ```bash
 scp -r -i ~/.ssh/id_rsa  HOST_NAME@VALIDATOR_NODE_IP_ADDRESS:~/.carbon/config/cert ~/.carbon/config/cert 
@@ -86,7 +105,7 @@ carbond oracle --grpc-url VALIDATOR_NODE_IP_ADDRESS:9090 --oracle-grpc-url VALID
 ```
 
 <br>
-**:memo: If you wish to disable the gRPC authentication, follow these instructions. :memo:**
+**:bulb: If you wish to disable the gRPC authentication, follow these instructions. :bulb:**
 <br><br>
 
 Update your app.toml config in `~/.carbon/config/app.toml`, under `gRPC Configuration`, on **BOTH VALIDATOR NODE AND ORACLE SERVICE NODE**


### PR DESCRIPTION
- add more detailed instructions for preupgrade
- handle case where validator is running oracle service on the same/different node